### PR TITLE
Handle Core Data save failures and unwrap player names

### DIFF
--- a/BibelSpiel/Views/EinstellungenSpielerView.swift
+++ b/BibelSpiel/Views/EinstellungenSpielerView.swift
@@ -35,7 +35,9 @@ struct EinstellungenSpielerView: View {
                                 PlaySound(sound: "select", type: "mp3", volume: self.settings.selectedSoundVolume)
                             }
                             withAnimation(.none) {
-                                self.settings.aktuellerSpielerName = spielerN.name!
+                                if let name = spielerN.name {
+                                    self.settings.aktuellerSpielerName = name
+                                }
                             }
                         }) {
                             Text(spielerN.name ?? "kein Name")
@@ -76,7 +78,8 @@ struct EinstellungenSpielerView: View {
                                 if self.spieler.count > 0 {
                                     var vorhanden = 0
                                     for spielerName in self.spieler {
-                                        if spielerName.name!.capitalized == self.neuerName.capitalized {
+                                        if let existingName = spielerName.name,
+                                           existingName.capitalized == self.neuerName.capitalized {
                                             // neu eingegebener Name schon vorhanden
                                             vorhanden += 1
                                             if self.settings.selectedSound == 1 {
@@ -89,7 +92,11 @@ struct EinstellungenSpielerView: View {
                                         let spieler = Spieler(context: self.moc)
                                         spieler.name = self.neuerName
                                         spieler.id = UUID()
-                                        try! self.moc.save()
+                                        do {
+                                            try self.moc.save()
+                                        } catch {
+                                            print("Fehler beim Speichern: \(error.localizedDescription)")
+                                        }
                                     }
                                     
                                 } else {
@@ -97,7 +104,11 @@ struct EinstellungenSpielerView: View {
                                     let spieler = Spieler(context: self.moc)
                                     spieler.name = self.neuerName
                                     spieler.id = UUID()
-                                    try! self.moc.save()
+                                    do {
+                                        try self.moc.save()
+                                    } catch {
+                                        print("Fehler beim Speichern: \(error.localizedDescription)")
+                                    }
                                 }
                             } else {
                                 if self.settings.selectedSound == 1 {
@@ -131,7 +142,11 @@ struct EinstellungenSpielerView: View {
             if spieler[index].name == self.settings.aktuellerSpielerName {
                 self.settings.aktuellerSpielerName = " - "
             }
-            try! moc.save()
+            do {
+                try moc.save()
+            } catch {
+                print("Fehler beim Speichern: \(error.localizedDescription)")
+            }
         }
     }
     

--- a/BibelSpiel/Views/StartView.swift
+++ b/BibelSpiel/Views/StartView.swift
@@ -95,8 +95,14 @@ struct StartView: View {
                         let spieler = Spieler(context: self.moc)
                         spieler.name = "Spieler 1"
                         spieler.id = UUID()
-                        self.settings.aktuellerSpielerName = spieler.name!
-                        try! self.moc.save()
+                        if let name = spieler.name {
+                            self.settings.aktuellerSpielerName = name
+                        }
+                        do {
+                            try self.moc.save()
+                        } catch {
+                            print("Fehler beim Speichern: \(error.localizedDescription)")
+                        }
                         self.settings.ersterStart = true
                         
                     }


### PR DESCRIPTION
## Summary
- replace force-unwraps of player names with safe optional binding
- wrap Core Data saves in `do`/`catch` blocks

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6897a421797083328c03dbc9264fb3b3