### PR TITLE
Prevent division by zero in time bar width calculation

### DIFF
--- a/BibelSpiel/Functions/CalculateBreiteAnzeigeZeit.swift
+++ b/BibelSpiel/Functions/CalculateBreiteAnzeigeZeit.swift
@@ -11,7 +11,8 @@ import SwiftUI
 
 
 public func CalculateBreiteAnzeigeZeit(breite: CGFloat, spielStartDatumInt: Int, spieldauerReferenz: Int) -> CGFloat {
-    
+    guard spieldauerReferenz > 0 else { return 0 }
+
     var prozent = spielStartDatumInt * 100 / spieldauerReferenz
     
     if prozent > 100 {

--- a/BibelSpiel/Globals.swift
+++ b/BibelSpiel/Globals.swift
@@ -103,14 +103,11 @@ class Globals: ObservableObject {
     
     
     func calculateBreiteAnzeigeZeit(breite: CGFloat) -> CGFloat {
-        
-        var prozent = Double(self.spielStartDatumInt * 100) / Double(spieldauerReferenz())
-        
-        if prozent > 100 {
-            prozent = 100
-        }
-        
-        return CGFloat((Int(breite) - 14) * Int(prozent) / 100)
+
+        let referenz = spieldauerReferenz()
+        guard referenz > 0 else { return 0 }
+
+        return CalculateBreiteAnzeigeZeit(breite: breite, spielStartDatumInt: self.spielStartDatumInt, spieldauerReferenz: referenz)
     }
     
     


### PR DESCRIPTION
## Summary
- Safeguard time bar width calculations against zero reference duration
- Delegate Globals.calculateBreiteAnzeigeZeit to shared helper to remove duplicate logic

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6897a6959ed883328e1f6dadbe6a2076