### PR TITLE
Define Bibelvers equality by order number

### DIFF
--- a/BibelSpiel/Functions/Bibelvers.swift
+++ b/BibelSpiel/Functions/Bibelvers.swift
@@ -18,7 +18,14 @@ struct Bibelvers: Hashable {
     var kapitelInt = 0
     var versInt = 0
     var txt = ""
-        
+
+    // Gleichheit und Hashwert basieren ausschließlich auf `reihenfolgeNr`.
+    // Zwei Bibelverse mit derselben Nummer gelten als identisch, auch wenn
+    // sich andere Eigenschaften unterscheiden.
+    static func == (lhs: Bibelvers, rhs: Bibelvers) -> Bool {
+        lhs.reihenfolgeNr == rhs.reihenfolgeNr
+    }
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(reihenfolgeNr)
     }


### PR DESCRIPTION
## Summary
- Define `Bibelvers` equality based solely on `reihenfolgeNr`
- Document this behavior in comments

## Testing
- `swiftc BibelSpiel/Functions/Bibelvers.swift /tmp/BibelversTestMain.swift -o /tmp/BibelversTestMain`
- `/tmp/BibelversTestMain`

------
https://chatgpt.com/codex/tasks/task_e_6897a98031608332bc81034c7de26b4b