### PR TITLE
Fix left-side Bible book bar not showing

### DIFF
--- a/BibelSpiel/Functions/Settings.swift
+++ b/BibelSpiel/Functions/Settings.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 class Settings: ObservableObject {
+
+    static let shared = Settings()
     
     @Published var ersterStart: Bool = UserDefaults.standard.bool(forKey: "ersterStart") {
         didSet {

--- a/BibelSpiel/Views/SpielEinstellungenView.swift
+++ b/BibelSpiel/Views/SpielEinstellungenView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SpielEinstellungenView: View {
     
     @EnvironmentObject var globals: Globals
-    @ObservedObject var settings = Settings()
+    @ObservedObject var settings = Settings.shared
     
     let hoehe = CGFloat(545)
     let hoeheHintergrundUeberschrift = CGFloat(60)
@@ -82,7 +82,7 @@ struct SpielEinstellungenView: View {
 
 struct Einstellungen: View {
     
-    @ObservedObject var settings = Settings()
+    @ObservedObject var settings = Settings.shared
     @EnvironmentObject var globals: Globals
     @Binding var showNeuerSpieler: Bool
     @State var showCredits = false

--- a/BibelSpiel/Views/SpielView.swift
+++ b/BibelSpiel/Views/SpielView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SpielView: View {
     
     @EnvironmentObject var globals: Globals
-    @ObservedObject var settings = Settings()
+    @ObservedObject var settings = Settings.shared
     
     let positionX: CGFloat = 1.22
     


### PR DESCRIPTION
## Summary
- share Settings instance across views
- honor left/right book bar preference in game view

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897aa1bc20083328668c61c73b005f9