### PR TITLE
Handle timer state outside TimerView rendering

### DIFF
--- a/BibelSpiel/Views/TimerView.swift
+++ b/BibelSpiel/Views/TimerView.swift
@@ -21,13 +21,13 @@ struct TimerView: View {
     var body: some View {
         
         ZStack {
-            Text("\(self.istTimerAktiv())")
             Text("\(self.timerInt > self.spielDauerReferenzInt ? "+": "")\(self.timerInt > self.spielDauerReferenzInt ? self.globals.zeitString(sekundenInt: self.timerInt - self.spielDauerReferenzInt) : self.globals.zeitString(sekundenInt: self.spielDauerReferenzInt - self.timerInt))")  // countUpString(from: referenceDate)
                 .font(.subheadline)
                 .bold()
                 .foregroundColor(Color.init("Dunkel"))
-            
-        }.onAppear() {
+
+        }
+        .onAppear() {
             self.globals.timerAktiv = true
             self.spielDauerReferenzInt = self.globals.spieldauerReferenz()
             self.timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
@@ -36,6 +36,13 @@ struct TimerView: View {
             }
             self.timer?.tolerance = 0.3
             RunLoop.current.add(self.timer!, forMode: RunLoop.Mode.common)
+        }
+        .onChange(of: globals.timerAktiv) { active in
+            guard !active else { return }
+            timer?.invalidate()
+            if globals.spielStartDatumInt == 0 {
+                globals.spielStartDatumInt = timerInt
+            }
         }
     }
     
@@ -66,19 +73,6 @@ struct TimerView: View {
                       components.second ?? 00)
     }
     
-    
-    func istTimerAktiv() -> String {
-        
-        if self.globals.timerAktiv {
-            return ""
-        } else {
-            self.timer?.invalidate()
-            if self.globals.spielStartDatumInt == 0 {
-                self.globals.spielStartDatumInt = self.timerInt
-            } 
-            return ""
-        }
-    }
     
 }
 


### PR DESCRIPTION
## Summary
- remove `istTimerAktiv` side-effect call from `TimerView` body
- use `onChange` to invalidate timer and store start time when the timer stops

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898d1cdf8588332844b81bf6b347b09